### PR TITLE
docs(release): prepare 0.10.8 patch notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## Unreleased
 
+### Highlights
+
+- Restore Web API and Connect-fallback search results by decoding Spotify's plural result containers, thanks @VACInc
+
 ### Changed
 
 - Refresh Go dependencies, including Kong, SweetCookie, SQLite, crypto, and formatting tools, and select Go 1.26.8 while retaining Go 1.26.7 support
 - Refresh GitHub Actions and CI tool pins, and build documentation with Node.js 26
-
-### Fixed
-
-- Decode Spotify's plural search result containers in the Web API client and Connect fallback, thanks @VACInc
 
 ## 0.10.7 - 2026-08-23
 


### PR DESCRIPTION
Prepare the Unreleased notes for a proposed 0.10.8 patch release. Lead with the already-landed search fix: Spotify returns plural result containers, while both Web API search paths previously looked for singular keys. Keep the dependency and CI refresh below that user-facing correction and preserve @VACInc's credit.

Only CHANGELOG.md changes, and all published release sections remain untouched. This does not add OAuth support or publish a release.

Validation:
- Full Go test suite and coverage gate: 90.4% total coverage.
- Built CLI imported three synthetic Firefox SQLite cookies through SweetCookie, persisted their exact values with mode 0600, reported the expected auth-status flags, and cleared the cache with empty stderr.
- Dependency/Actions audit: selected application dependencies and Actions are current except libc v1.75.7, deliberately held because modernc.org/sqlite v1.58.0 documents an exact pairing with libc v1.75.6. Other outdated graph modules are unused or dependency test tools.
- Independent autoreview and exact-head CI details are recorded in the proof comment.

Release recommendation: 0.10.8 (patch). OAuth #57 remains a separate product decision; #61 is superseded by #57. Release authorization and the signed, notarized GitHub/Homebrew workflow remain separate steps.
